### PR TITLE
finetuning: add missing use_fast arg to argument parser

### DIFF
--- a/finetuning/sa/run_sa.py
+++ b/finetuning/sa/run_sa.py
@@ -52,6 +52,7 @@ class ModelArguments:
     tokenizer_name: Optional[str] = field(
         default=None, metadata={"help": "Pretrained tokenizer name or path if not the same as model_name"},
     )
+    use_fast: bool = field(default=False, metadata={"help": "Set this flag to use fast tokenization."})
     cache_dir: Optional[str] = field(
         default=None, metadata={"help": "Where do you want to store the pretrained models downloaded from s3"},
     )


### PR DESCRIPTION
Hi guys,

I'm currently using this great repo for re-evaluating all my models in the [Turkish LM model zoo](https://github.com/stefan-it/turkish-bert).

When using the fine-tuning script for sentiment analysis, I just found out that the `use_fast` argument is not added to the hf argument parser, and this throws an execption later, when it will be used:

https://github.com/Adapter-Hub/hgiyt/blob/9db6b6d1aab264cdf9e3131adb8157bcaf162410/finetuning/sa/run_sa.py#L141

This PR fixes it :)